### PR TITLE
fix pretty-print without pl.pretty

### DIFF
--- a/cwtest.lua
+++ b/cwtest.lua
@@ -4,6 +4,7 @@ if not has_strict then
   print("WARNING: pl.strict not found, strictness not enforced.")
 end
 if not has_pretty then
+  pretty = nil
   print("WARNING: pl.pretty not found, using alternate formatter.")
 end
 


### PR DESCRIPTION
When run without Penlight, the require 'pl/pretty' returns nil, stack traceback.  This patch ensures that the local pretty is set to nil so the pretty_write check works properly
